### PR TITLE
Remove broken version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ install: ## Install yuri
 	go install src/yuri.go
 
 release: ## Publish release to equinox.io | args: version
-	ifndef version
-	  $(error version is undefined)
-	endif
 	@echo equinox release --config \"./equinox.yaml\" --version \"${version}\" --token \"****\" ./src/yuri.go
 	@equinox release --config "./equinox.yaml" --version "${version}" --token "${EQUINOX_TOKEN}" ./src/yuri.go
 


### PR DESCRIPTION
Still errors out with a good error message:

```
$ make release
equinox release --config "./equinox.yaml" --version "" --token "****" ./src/yuri.go
The following command line flags are required and must be specified when
building a release:

   --version        version string of the new release

make: *** [release] Error 1
```