### PR TITLE
Fix version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Set version correctly
 
 ## 0.1.0 - 2017-01-02
 

--- a/src/yuri.go
+++ b/src/yuri.go
@@ -38,6 +38,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "yuri"
 	app.Usage = "parse the urlz!"
+	app.Version = "0.1.0"
 	app.Action = func(c *cli.Context) error {
 		if len(c.Args()) < 1 {
 			log.Fatal("No arguments. Usage: yuri <URI>")


### PR DESCRIPTION
Fixes #19 

### Before

```
$ go run src/yuri.go -v
yuri version 0.0.0
```

### After

```
$ go run src/yuri.go -v
yuri version 0.1.0
```