### PR TITLE
Fix #2: Add hostname and port to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ $ yuri "https://username:password@stage.example.com:443/path+to+foo?query1=1&que
 {
   "fragment": "FRAG",
   "host": "stage.example.com:443",
+  "hostname": "stage.example.com",
+  "port": "443",
   "opaque": "",
   "password": "password",
   "path": "/path+to+foo",
@@ -53,6 +55,8 @@ Here are the JSON fields provided by yuri:
 * `username`: basic auth username
 * `password`: basic auth password
 * `host`: host or host:port
+* `hostname`: host without port
+* `port`: port
 * `path`: path
 * `rawpath`: encoded path
 * `rawquery`: encoded query values, without `?`

--- a/src/yuri.go
+++ b/src/yuri.go
@@ -6,9 +6,53 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli"
 )
+
+// Following code taken from https://github.com/golang/go/commit/1ff19201fd898c3e1a0ed5d3458c81c1f062570b
+// TODO: Replace Hostname(), Port(), stripPort(), and portOnly() with native methods once Go 1.8 is available
+
+// Hostname returns u.Host, without any port number.
+//
+// If Host is an IPv6 literal with a port number, Hostname returns the
+// IPv6 literal without the square brackets. IPv6 literals may include
+// a zone identifier.
+func Hostname(hostport string) string {
+	return stripPort(hostport)
+}
+
+// Port returns the port part of u.Host, without the leading colon.
+// If u.Host doesn't contain a port, Port returns an empty string.
+func Port(hostport string) string {
+	return portOnly(hostport)
+}
+
+func stripPort(hostport string) string {
+	colon := strings.IndexByte(hostport, ':')
+	if colon == -1 {
+		return hostport
+	}
+	if i := strings.IndexByte(hostport, ']'); i != -1 {
+		return strings.TrimPrefix(hostport[:i], "[")
+	}
+	return hostport[:colon]
+}
+
+func portOnly(hostport string) string {
+	colon := strings.IndexByte(hostport, ':')
+	if colon == -1 {
+		return ""
+	}
+	if i := strings.Index(hostport, "]:"); i != -1 {
+		return hostport[i+len("]:"):]
+	}
+	if strings.Contains(hostport, "]") {
+		return ""
+	}
+	return hostport[colon+len(":"):]
+}
 
 // CreateURIMap builds a map out of a URL struct for JSON encoding.
 func CreateURIMap(u *url.URL) map[string]string {
@@ -18,6 +62,8 @@ func CreateURIMap(u *url.URL) map[string]string {
 	m["scheme"] = u.Scheme
 	m["opaque"] = u.Opaque
 	m["host"] = u.Host
+	m["hostname"] = Hostname(u.Host)
+	m["port"] = Port(u.Host)
 	m["path"] = u.Path
 	m["rawpath"] = u.EscapedPath()
 	m["rawquery"] = u.RawQuery

--- a/src/yuri_test.go
+++ b/src/yuri_test.go
@@ -11,6 +11,8 @@ func TestCreateURIMapWithNoUsernameAndPassword(t *testing.T) {
 	em := map[string]string{
 		"fragment": "FRAG",
 		"host":     "stage.example.com:443",
+		"hostname": "stage.example.com",
+		"port":     "443",
 		"opaque":   "",
 		"password": "",
 		"path":     "/path+to+foo",
@@ -28,6 +30,8 @@ func TestCreateURIMapWithUsername(t *testing.T) {
 	em := map[string]string{
 		"fragment": "FRAG",
 		"host":     "stage.example.com:443",
+		"hostname": "stage.example.com",
+		"port":     "443",
 		"opaque":   "",
 		"password": "",
 		"path":     "/path+to+foo",
@@ -45,6 +49,8 @@ func TestCreateURIMapWithUsernameAndPassword(t *testing.T) {
 	em := map[string]string{
 		"fragment": "FRAG",
 		"host":     "stage.example.com:443",
+		"hostname": "stage.example.com",
+		"port":     "443",
 		"opaque":   "",
 		"password": "password",
 		"path":     "/path+to+foo",
@@ -54,6 +60,25 @@ func TestCreateURIMapWithUsernameAndPassword(t *testing.T) {
 		"username": "username",
 	}
 	parsedURI, _ := url.Parse("https://username:password@stage.example.com:443/path+to+foo?query1=1&query2=2#FRAG")
+	rm := CreateURIMap(parsedURI)
+	assert.Equal(t, rm, em)
+}
+
+func TestCreateURIMapWithNoPort(t *testing.T) {
+	em := map[string]string{
+		"fragment": "FRAG",
+		"host":     "stage.example.com",
+		"hostname": "stage.example.com",
+		"port":     "",
+		"opaque":   "",
+		"password": "password",
+		"path":     "/path+to+foo",
+		"rawpath":  "/path+to+foo",
+		"rawquery": "query1=1&query2=2",
+		"scheme":   "https",
+		"username": "username",
+	}
+	parsedURI, _ := url.Parse("https://username:password@stage.example.com/path+to+foo?query1=1&query2=2#FRAG")
 	rm := CreateURIMap(parsedURI)
 	assert.Equal(t, rm, em)
 }


### PR DESCRIPTION
Backports the code from Go 1.8: https://github.com/golang/go/commit/1ff19201fd898c3e1a0ed5d3458c81c1f062570b

Example:

```
{
  "fragment": "FRAG",
  "host": "stage.example.com:443",
  "hostname": "stage.example.com",
  "port": "443",
  "opaque": "",
  "password": "password",
  "path": "/path+to+foo",
  "rawpath": "/path+to+foo",
  "rawquery": "query1=1&query2=2",
  "scheme": "https",
  "username": "username"
}
```